### PR TITLE
Fix for issue #16

### DIFF
--- a/src/Elmah.Contrib.WebApi/ElmahExceptionLogger.cs
+++ b/src/Elmah.Contrib.WebApi/ElmahExceptionLogger.cs
@@ -29,14 +29,14 @@ namespace Elmah.Contrib.WebApi
 				return null;
 
 			object value;
-			if (!request.Properties.TryGetValue("MS_HttpContext", out value))
-				return null;
+			if (request.Properties.TryGetValue("MS_HttpContext", out value))
+			{
+				HttpContextBase context = value as HttpContextBase;
+				if (context != null)
+					return context.ApplicationInstance.Context;
+			}
 
-			HttpContextBase context = value as HttpContextBase;
-			if (context == null)
-				return null;
-
-			return context.ApplicationInstance.Context;
+			return HttpContext.Current;
 		}
 	}
 }


### PR DESCRIPTION
Only try to get the application context if the request property is found, otherwise fallback to `HttpContext.Current` as a last ditch attempt at getting a context which could also return `null` but hey, we tried...